### PR TITLE
Added support for the 'none' terminal type specified via the TERM environment variable.

### DIFF
--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -328,7 +328,7 @@ class ConsoleApplication(object):
             self._uprint(Style.BRIGHT, message, Style.RESET_ALL)
 
     def _uprint(self, *args):
-        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith("\033"))
         print(args)
 
     def _print(self, *args, **kwargs):

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -16,7 +16,7 @@ if platform.system() == 'Windows':
     import msvcrt
 
 import colorama
-from colorama import Fore, Style, Cursor
+from colorama import Cursor, Fore, Style
 import frida
 
 

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -314,7 +314,7 @@ class ConsoleApplication(object):
 
     def _clear_status(self):
         if not self._plain_terminal and self._console_state == ConsoleState.STATUS:
-            self._uprint(Cursor.UP(), (80 * " "))
+            self._uprint(Cursor.UP(), 80 * " ")
 
     def _update_status(self, message):
         if self._have_terminal and not self._plain_terminal:

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -333,7 +333,7 @@ class ConsoleApplication(object):
 
     def _print(self, *args, **kwargs):
         # Filter out any args that are escape codes and turn them into a single element tuple
-        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith("\033"))
         args = [args]
 
         encoded_args = []

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -16,7 +16,7 @@ if platform.system() == 'Windows':
     import msvcrt
 
 import colorama
-from colorama import Fore, Style
+from colorama import Fore, Style, Cursor
 import frida
 
 
@@ -132,6 +132,7 @@ class ConsoleApplication(object):
         self._exit_status = None
         self._console_state = ConsoleState.EMPTY
         self._have_terminal = sys.stdin.isatty() and sys.stdout.isatty() and not os.environ.get("TERM", '') == "dumb"
+        self._plain_terminal = os.environ.get("TERM", '').lower() == "none"
         self._quiet = False
         if sum(map(lambda v: int(v is not None), (self._device_id, self._device_type, self._host))) > 1:
             parser.error("Only one of -D, -U, -R, and -H may be specified")
@@ -308,25 +309,34 @@ class ConsoleApplication(object):
 
     def _on_session_detached(self, reason):
         message = reason[0].upper() + reason[1:].replace("-", " ")
-        self._print(Fore.RED + Style.BRIGHT + message + Style.RESET_ALL)
+        self._print(Fore.RED, Style.BRIGHT, message, Style.RESET_ALL)
         self._exit(1)
 
     def _clear_status(self):
-        if self._console_state == ConsoleState.STATUS:
-            print("\033[A" + (80 * " "))
+        if not self._plain_terminal and self._console_state == ConsoleState.STATUS:
+            self._uprint(Cursor.UP(), (80 * " "))
 
     def _update_status(self, message):
-        if self._have_terminal:
+        if self._have_terminal and not self._plain_terminal:
             if self._console_state == ConsoleState.STATUS:
-                cursor_position = "\033[A"
+                cursor_position = Cursor.UP()
             else:
                 cursor_position = ""
-            print("%-80s" % (cursor_position + Style.BRIGHT + message + Style.RESET_ALL,))
+            self._uprint(cursor_position, Style.BRIGHT, "%-80s"% message, Style.RESET_ALL)
             self._console_state = ConsoleState.STATUS
         else:
-            print(Style.BRIGHT + message + Style.RESET_ALL)
+            self._uprint(Style.BRIGHT, message, Style.RESET_ALL)
+
+    def _uprint(self, *args):
+        args = str().join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        print(args)
 
     def _print(self, *args, **kwargs):
+        # filter out any args that are escape codes and turn them into a single element tuple
+        args = str().join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        args = [args]
+
+        # continue to do the rest of the stupid stuff
         encoded_args = []
         if sys.version_info[0] >= 3:
             string_type = str
@@ -348,7 +358,7 @@ class ConsoleApplication(object):
             self._print(text)
         else:
             color = Fore.RED if level == 'error' else Fore.YELLOW
-            self._print(color + Style.BRIGHT + text + Style.RESET_ALL)
+            self._print(color, Style.BRIGHT, text, Style.RESET_ALL)
 
 
 def find_device(type):

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -132,7 +132,7 @@ class ConsoleApplication(object):
         self._exit_status = None
         self._console_state = ConsoleState.EMPTY
         self._have_terminal = sys.stdin.isatty() and sys.stdout.isatty() and not os.environ.get("TERM", '') == "dumb"
-        self._plain_terminal = os.environ.get("TERM", '').lower() == "none"
+        self._plain_terminal = os.environ.get("TERM", "").lower() == "none"
         self._quiet = False
         if sum(map(lambda v: int(v is not None), (self._device_id, self._device_type, self._host))) > 1:
             parser.error("Only one of -D, -U, -R, and -H may be specified")
@@ -328,15 +328,14 @@ class ConsoleApplication(object):
             self._uprint(Style.BRIGHT, message, Style.RESET_ALL)
 
     def _uprint(self, *args):
-        args = str().join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
         print(args)
 
     def _print(self, *args, **kwargs):
-        # filter out any args that are escape codes and turn them into a single element tuple
-        args = str().join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
+        # Filter out any args that are escape codes and turn them into a single element tuple
+        args = "".join(arg for arg in args if not self._plain_terminal or not arg.startswith('\033'))
         args = [args]
 
-        # continue to do the rest of the stupid stuff
         encoded_args = []
         if sys.version_info[0] >= 3:
             string_type = str

--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -322,7 +322,7 @@ class ConsoleApplication(object):
                 cursor_position = Cursor.UP()
             else:
                 cursor_position = ""
-            self._uprint(cursor_position, Style.BRIGHT, "%-80s"% message, Style.RESET_ALL)
+            self._uprint(cursor_position, Style.BRIGHT, "%-80s" % message, Style.RESET_ALL)
             self._console_state = ConsoleState.STATUS
         else:
             self._uprint(Style.BRIGHT, message, Style.RESET_ALL)

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -114,7 +114,7 @@ def main():
                     if thread_id != self._last_event_tid:
                         self._print(attributes, "           ", "/* TID %#x */" % thread_id, Style.RESET_ALL)
                         self._last_event_tid = thread_id
-                    self._print("%6d ms"% timestamp, "  ", attributes, indent, message, no_attributes)
+                    self._print("%6d ms" % timestamp, "  ", attributes, indent, message, no_attributes)
 
         def on_trace_handler_create(self, function, handler, source):
             if self._quiet:

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -101,7 +101,7 @@ def main():
                 self._resume()
 
         def on_trace_error(self, error):
-            self._print(Fore.RED + Style.BRIGHT + "Error" + Style.RESET_ALL + ": " + error['message'])
+            self._print(Fore.RED, Style.BRIGHT, "Error", Style.RESET_ALL, ": ", error['message'])
 
         def on_trace_events(self, events):
             no_attributes = Style.RESET_ALL
@@ -112,9 +112,9 @@ def main():
                     indent = depth * "   | "
                     attributes = self._get_attributes(thread_id)
                     if thread_id != self._last_event_tid:
-                        self._print("%s           /* TID 0x%x */%s" % (attributes, thread_id, Style.RESET_ALL))
+                        self._print(attributes, '           ', "/* TID %#x */" % thread_id, Style.RESET_ALL)
                         self._last_event_tid = thread_id
-                    self._print("%6d ms  %s%s%s%s" % (timestamp, attributes, indent, message, no_attributes))
+                    self._print("%6d ms"% timestamp, '  ', attributes, indent, message, no_attributes)
 
         def on_trace_handler_create(self, function, handler, source):
             if self._quiet:

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -112,9 +112,9 @@ def main():
                     indent = depth * "   | "
                     attributes = self._get_attributes(thread_id)
                     if thread_id != self._last_event_tid:
-                        self._print(attributes, '           ', "/* TID %#x */" % thread_id, Style.RESET_ALL)
+                        self._print(attributes, "           ", "/* TID %#x */" % thread_id, Style.RESET_ALL)
                         self._last_event_tid = thread_id
-                    self._print("%6d ms"% timestamp, '  ', attributes, indent, message, no_attributes)
+                    self._print("%6d ms"% timestamp, "  ", attributes, indent, message, no_attributes)
 
         def on_trace_handler_create(self, function, handler, source):
             if self._quiet:


### PR DESCRIPTION
This closes issue #7 by allowing the user to specify 'none' as `TERM` in their environment to avoid emitting terminal escape codes.

Explicit usage of escape codes that were being printed were replaced to use the ones defined in colorama. To filter out the escape codes it was noticed that only standard string concatenation was used via the "+" operator, and so this logic was moved into the `self._*print` functions. This changes the semantics of `self._print` so that each individual arg is not space-separated, but since it wasn't used anywhere it shouldn't matter.

---
```
Added support for the 'none' terminal type specified via the TERM environment variable.

frida-tools/application.py:
    Added the 'none' terminal type to set the '_plain_terminal' property.
    Replaced all explicit cursor position escape codes with the respective
        functions in `colorama.Cursor`.
    Added an implementation of ._uprint() to replace the regular calls to
        the `print()`  function.
    Split up all of the string concatenation that is used to emit terminal
        escape codes into separate variable args for `self._*print()`.
    Added filters to `self._*print` to remove terminal escape codes that
        get emitted.

frida-tools/{repl,tracer}.py:
    Split up all of the string concatenation that is used to emit terminal
        escape codes into separate variable args for `self._*print()`.
```