### PR TITLE
Fix parameter error in OutputFile constructor

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -930,7 +930,7 @@ class FileRepository(Repository):
 
 class OutputFile(object):
     def __init__(self, filename):
-        self._fd = codecs.open(self.filename, 'wb', 'utf-8')
+        self._fd = codecs.open(filename, 'wb', 'utf-8')
 
     def close(self):
         self._fd.close()


### PR DESCRIPTION
The `frida-trace` command was throwing errors about an invalid output filename. The `filename` parameter in `tracer.py` was qualified with a `self` reference where it shouldn't be.