### PR TITLE
Implemented "--decorate" command line option to include module name in onEnter() log string

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -53,7 +53,7 @@ def main():
             parser.add_option("-s", "--include-debug-symbol", help="include DEBUG_SYMBOL", metavar="DEBUG_SYMBOL",
                     type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_debug_symbol,))
             parser.add_option("-q", "--quiet", help="do not format output messages", action='store_true', default=False)
-            parser.add_option("-d", "--decorate", help="Add module name to generated onEnter log statement", action='store_true', default=False)    #brown
+            parser.add_option("-d", "--decorate", help="Add module name to generated onEnter log statement", action='store_true', default=False)
             parser.add_option("-o", "--output", help="dump messages to file", metavar="OUTPUT", type='string')
             self._profile_builder = pb
 

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -776,9 +776,9 @@ class Repository(object):
                     pass
 
             if decorate:
-                module_string = ' [%s]' %  function.module.name
+                module_string = " [%s]" %  function.module.name
             else:
-                module_string = ''
+                module_string = ""
 
             if len(args) == 0:
                 log_str = "'%(name)s()%(module_string)s'" % { "name": function.name, "module_string" : module_string }


### PR DESCRIPTION
**Summary**

I have implemented a new "--decorate" command line option that will add the module name as part of the auto-generated onEnter log() string.  Whereas a non-decorated onEnter() log string looks like:

log('jinit_c_coef_controller()');
log('sub_2fec()');

Decorated log strings have the module added:

log('jinit_c_coef_controller() [imglib2.dll]');
log('sub_2fec() [imglib2.dll]');

**Rationale**

I used Frida to trace many hundreds of functions across multiple modules.  I found myself lost when reading the trace output: I couldn't easily tell from which module a traced function came from.  The "--decorate" option tells frida-trace to include the module name in the auto-generated onEnter() log string.

**Details**

- The "--decorate" option will not insert the module name into a previously auto-generated handler script.