### PR TITLE
-i/-x OPTIONS SUPPORT PATTERN FORM '<MODULE-REGEX>!<FUNCTION-REGEX>'

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -345,6 +345,22 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
+function includeFunction(pattern, workingSet) {
+    var parseResult = parseExportsFunctionPattern(pattern);
+    moduleResolver().enumerateMatches('exports:' + parseResult.module + '!' + parseResult.function).forEach(function (m) {
+        workingSet[m.address.toString()] = moduleExportFromMatch(m);
+    });
+    return workingSet;
+}
+
+function excludeFunction(pattern, workingSet) {
+    var parseResult = parseExportsFunctionPattern(pattern);
+    moduleResolver().enumerateMatches('exports:' + parseResult.module + '!' + parseResult.function).forEach(function (m) {
+        delete workingSet[m.address.toString()];
+    });
+    return workingSet;
+}
+
 function parseExportsFunctionPattern(pattern) {
     var res = pattern.split('!');
     var m, f;
@@ -356,27 +372,10 @@ function parseExportsFunctionPattern(pattern) {
         m = (res[0] === '') ? '*' : res[0];
         f = (res[1] === '') ? '*' : res[1];
     }
-    
     return {
         module: m,
         function: f
     };
-}
-
-function includeFunction(pattern, workingSet) {
-    var obj = parseExportsFunctionPattern(pattern);
-    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
-        workingSet[m.address.toString()] = moduleExportFromMatch(m);
-    });
-    return workingSet;
-}
-
-function excludeFunction(pattern, workingSet) {
-    var obj = parseExportsFunctionPattern(pattern);
-    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
-        delete workingSet[m.address.toString()];
-    });
-    return workingSet;
 }
 
 function includeRelativeFunction(func, workingSet) {

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -363,8 +363,8 @@ function excludeFunction(pattern, workingSet) {
 
 function parseExportsFunctionPattern(pattern) {
     var res = pattern.split('!');
+
     var m, f;
-    
     if (res.length === 1) {
         m = '*';
         f = res[0];
@@ -372,6 +372,7 @@ function parseExportsFunctionPattern(pattern) {
         m = (res[0] === '') ? '*' : res[0];
         f = (res[1] === '') ? '*' : res[1];
     }
+
     return {
         module: m,
         function: f

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -345,18 +345,16 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
-function parseExportsFunctionPattern (pattern) {
-    var m;
-    var f;
-    var res = pattern.split ('!');
+function parseExportsFunctionPattern(pattern) {
+    var res = pattern.split('!');
+    var m, f;
     
-    if (res.length == 1) {
+    if (res.length === 1) {
         m = '*';
         f = res[0];
-    }
-    else {
-        m = (res[0] == '' ? '*' : res[0]);
-        f = (res[1] == '' ? '*' : res[1]);
+    } else {
+        m = (res[0] === '') ? '*' : res[0];
+        f = (res[1] === '') ? '*' : res[1];
     }
     
     return {
@@ -366,8 +364,7 @@ function parseExportsFunctionPattern (pattern) {
 }
 
 function includeFunction(pattern, workingSet) {
-    var obj = parseExportsFunctionPattern (pattern);
-    
+    var obj = parseExportsFunctionPattern(pattern);
     moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         workingSet[m.address.toString()] = moduleExportFromMatch(m);
     });
@@ -375,8 +372,7 @@ function includeFunction(pattern, workingSet) {
 }
 
 function excludeFunction(pattern, workingSet) {
-    var obj = parseExportsFunctionPattern (pattern);
-    
+    var obj = parseExportsFunctionPattern(pattern);
     moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         delete workingSet[m.address.toString()];
     });

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -345,15 +345,39 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
+function parseExportsFunctionPattern (pattern) {
+    var m;
+    var f;
+    var res = pattern.split ('!');
+    
+    if (res.length == 1) {
+        m = '*';
+        f = res[0];
+    }
+    else {
+        m = (res[0] == '' ? '*' : res[0]);
+        f = (res[1] == '' ? '*' : res[1]);
+    }
+    
+    return {
+        module: m,
+        function: f
+    };
+}
+
 function includeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         workingSet[m.address.toString()] = moduleExportFromMatch(m);
     });
     return workingSet;
 }
 
 function excludeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         delete workingSet[m.address.toString()];
     });
     return workingSet;


### PR DESCRIPTION
Currently the -i (IncludeFunction) and -x (ExcludeFunction) command
line options take a function regex pattern, but will match functions
in *ALL* modules in the process.  There is no easy way to request a
function regex pattern in a *single* module.

This commit enhances the -i and -x function options to support patterns
that specify both a module *and* a function regex.

Examples:

`-i '*free*'`
        Matches all functions with 'free' in its name in ALL modules
        Equivalent to `exports:*!*free*`

`-i 'msvcrt.dll!*cpy*'`
        Matches all functions with 'cpy' only in msvcrt.dll
        Equivalent to `exports:msvcrt.dll!*cpy*`

`-i 'msvcrt.dll!'`
        Equivalent to `exports:msvcrt.dll:*`

`-i '!*cpy*'`
        Equivalent to `exports:*!*cpy*`