### PR TITLE
--options-file command line option: support passing additional arguments via a text file

### DIFF
--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -15,11 +15,11 @@ import threading
 from time import time
 if platform.system() == 'Windows':
     import msvcrt
+import shlex
 
 import colorama
 from colorama import Cursor, Fore, Style
 import frida
-import shlex
 
 
 def input_with_timeout(timeout):
@@ -458,14 +458,14 @@ def compute_real_args(parser):
 
     while perform_pass:
         offset = find_arg_file_offset(real_args, parser)
-        if (offset < 0):
+        if offset == -1:
             perform_pass = False
             continue
 
-        file_path = real_args[offset+1]
+        file_path = real_args[offset + 1]
 
         if file_path in files_processed:
-            parser.error("File '{}' given twice as -O argument".format (file_path))
+            parser.error("File '{}' given twice as -O argument".format(file_path))
 
         if os.path.isfile(file_path):
             with codecs.open(file_path, 'r', 'utf-8') as f:
@@ -479,8 +479,8 @@ def compute_real_args(parser):
     return real_args
 
 def find_arg_file_offset(arglist, parser):
-    for i in range(len(arglist)):
-        if (arglist[i] == '-O') or (arglist[i] == '--options-file'):
+    for i,arg in enumerate(arglist):
+        if arg in ("-O", "--options-file"):
             if i < len(arglist) - 1:
                 return i
             else:

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -347,20 +347,16 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
-function parseExportsFunctionPattern (pattern) {
-    var m;
-    var f;
-    var res = pattern.split ('!');
-    
-    if (res.length == 1) {
+function parseExportsFunctionPattern(pattern) {
+    var res = pattern.split('!');
+    var m, f;
+    if (res.length === 1) {
         m = '*';
         f = res[0];
+    } else {
+        m = (res[0] === '') ? '*' : res[0];
+        f = (res[1] === '') ? '*' : res[1];
     }
-    else {
-        m = (res[0] == '' ? '*' : res[0]);
-        f = (res[1] == '' ? '*' : res[1]);
-    }
-    
     return {
         module: m,
         function: f

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -345,15 +345,39 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
+function parseExportsFunctionPattern (pattern) {
+    var m;
+    var f;
+    var res = pattern.split ('!');
+    
+    if (res.length == 1) {
+        m = '*';
+        f = res[0];
+    }
+    else {
+        m = (res[0] == '' ? '*' : res[0]);
+        f = (res[1] == '' ? '*' : res[1]);
+    }
+    
+    return {
+        module: m,
+        function: f
+    };
+}
+
 function includeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         workingSet[m.address.toString()] = moduleExportFromMatch(m);
     });
     return workingSet;
 }
 
 function excludeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         delete workingSet[m.address.toString()];
     });
     return workingSet;


### PR DESCRIPTION
In my work with Frida I have generated many hundreds of -i / -a command line arguments.  Running under Windows I have hit the maximal command line size, and have even encountered the same problem with Linux.

This feature allow passing an unlimited number of arguments via text files.  These text files are tokenized correctly and accumulated, eventually being passed to `parser.parse_args` for parsing and processing.

The feature opens the door to automated generated files of hundreds or even thousands of arguments, typical of modern day usage of tools like decompilers (e.g., IDA or Ghidra) and frida-trace.