### PR TITLE
Populate <state> global variable with user data before beginning trace session

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -347,20 +347,16 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
-function parseExportsFunctionPattern (pattern) {
-    var m;
-    var f;
-    var res = pattern.split ('!');
-    
-    if (res.length == 1) {
+function parseExportsFunctionPattern(pattern) {
+    var res = pattern.split('!');
+    var m, f;
+    if (res.length === 1) {
         m = '*';
         f = res[0];
+    } else {
+        m = (res[0] === '') ? '*' : res[0];
+        f = (res[1] === '') ? '*' : res[1];
     }
-    else {
-        m = (res[0] == '' ? '*' : res[0]);
-        f = (res[1] == '' ? '*' : res[1]);
-    }
-    
     return {
         module: m,
         function: f

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -69,13 +69,7 @@ def main():
             self._decorate = options.decorate
             self._output = None
             self._output_path = options.output
-            self._userdata = self.escape_char(options.userdata, '"')
-
-        def escape_char(self, str, c):
-            if (str == None):
-                return ''
-            else:
-                return str.replace(c, '\\'+c)
+            self._userdata = options.userdata
 
         def _needs_target(self):
             return True
@@ -544,10 +538,7 @@ class Tracer(object):
         self._profile = profile
         self._script = None
         self._log_handler = log_handler
-        
-        self._userdata = userdata
-        if self._userdata == None:
-            self._userdata = ''
+        self._userdata = userdata if userdata is not None else ""
 
     def start_trace(self, session, runtime, ui):
         def on_create(*args):
@@ -609,9 +600,10 @@ var state = {};
 var pending = [];
 var timer = null;
 
-state.userdata = "%(userdata)s";
-
 rpc.exports = {
+    init: function (stage, parameters) {
+        state.userdata = %{userdata}s;
+    },
     dispose: function () {
         flush();
     },

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -345,15 +345,39 @@ function excludeModule(pattern, workingSet) {
     return workingSet;
 }
 
+function parseExportsFunctionPattern (pattern) {
+    var m;
+    var f;
+    var res = pattern.split ('!');
+    
+    if (res.length == 1) {
+        m = '*';
+        f = res[0];
+    }
+    else {
+        m = (res[0] == '' ? '*' : res[0]);
+        f = (res[1] == '' ? '*' : res[1]);
+    }
+    
+    return {
+        module: m,
+        function: f
+    };
+}
+
 function includeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         workingSet[m.address.toString()] = moduleExportFromMatch(m);
     });
     return workingSet;
 }
 
 function excludeFunction(pattern, workingSet) {
-    moduleResolver().enumerateMatches('exports:*!' + pattern).forEach(function (m) {
+    var obj = parseExportsFunctionPattern (pattern);
+    
+    moduleResolver().enumerateMatches('exports:' + obj['module'] + '!' + obj['function']).forEach(function (m) {
         delete workingSet[m.address.toString()];
     });
     return workingSet;


### PR DESCRIPTION
The ability for the user to pass a session-specific string on the command line and have it stored in the <state> global variable before starting the trace will allow more dynamic control of handler behaviour.  This data-driven, rather than code-driven, model enables the user to modify what a handler will do without having to modify its code on a continual basis.