### PR TITLE
BUGFIX: Handle "--options-file=<path>" in options file

### DIFF
--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -453,11 +453,11 @@ class ConsoleApplication(object):
 
 
 def compute_real_args(parser):
-    real_args = normalize_raw_args(sys.argv[1:])
+    real_args = normalize_options_file_args(sys.argv[1:])
 
     files_processed = set()
     while True:
-        offset = find_arg_file_offset(real_args, parser)
+        offset = find_options_file_offset(real_args, parser)
         if offset == -1:
             break
 
@@ -471,13 +471,13 @@ def compute_real_args(parser):
         else:
             parser.error("File '{}' following -O option is not a valid file".format(file_path))
 
-        real_args = insert_new_args_in_list(real_args, offset, new_arg_text)
+        real_args = insert_options_file_args_in_list(real_args, offset, new_arg_text)
         files_processed.add(file_path)
 
     return real_args
 
 
-def normalize_raw_args(raw_args):
+def normalize_options_file_args(raw_args):
     result = []
     for arg in raw_args:
         if arg.startswith("--options-file="):
@@ -488,7 +488,7 @@ def normalize_raw_args(raw_args):
     return result
 
 
-def find_arg_file_offset(arglist, parser):
+def find_options_file_offset(arglist, parser):
     for i, arg in enumerate(arglist):
         if arg in ("-O", "--options-file"):
             if i < len(arglist) - 1:
@@ -498,8 +498,9 @@ def find_arg_file_offset(arglist, parser):
     return -1
 
 
-def insert_new_args_in_list(args, offset, new_arg_text):
+def insert_options_file_args_in_list(args, offset, new_arg_text):
     new_args = shlex.split(new_arg_text)
+    new_args = normalize_options_file_args(new_args)
     new_args_list = args[:offset] + new_args + args[offset + 2:]
     return new_args_list
 


### PR DESCRIPTION
The previous release of Frida introduced the "--options-file=<path>"
option.  This option allows placing any command line options and flags
in a text file and specifying the text file's path on the command line.

The short form of "--options-file" is "-O".

The code is meant to support "--options-file=" options embedded within
an options file, like so:

Command line:

    frida-trace -p 5620 --options-file=options-file.1.txt

options-file.1.txt:

    --options-file=options-file.2.txt

options-file.2.txt:

    -i "str*"
    -X "KERNELBASE.dll"

This should produce results equivalent to the command line:

    frida-trace -p 5620 -i "str*" -X "KERNELBASE.dll"

There is a bug whereby the "--options-file=<path>" on the command line
is processed correctly, but the embedded "--options-file=<path>" is not.

Note that there is no problem if the user uses the short form "-O" in
the embedded options file, only if the long form "--options-file=<path>"
is used.

The fix is to call the "normalize_options_file_args()" function both
when processing the command line *and* when processing the options
files themselves.

In addition, several of the functions were renamed for clarity reasons.