### PR TITLE
Fix incorrect cached resolver name

### DIFF
--- a/agents/tracer/agent.ts
+++ b/agents/tracer/agent.ts
@@ -557,7 +557,7 @@ class Agent {
             } catch (e) {
                 throw new Error("Objective-C runtime is not available");
             }
-            this.cachedModuleResolver = resolver;
+            this.cachedObjcResolver = resolver;
         }
         return resolver;
     }


### PR DESCRIPTION
When an ObjC resolver is created, it is incorrectly cached under  `this.cachedModuleResolver` instead of `this.cachedObjcResolver`.  This results in cryptic errors if a trace combines both ObjC and function tracing when the ObjC resolver is initialized first, since the wrong resolver ends up being used to resolve the functions.