### PR TITLE
Enable editor editing in prompt toolkit

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -57,7 +57,8 @@ def main():
                                           history=history,
                                           completer=self._completer,
                                           complete_in_thread=True,
-                                          enable_open_in_editor=True)
+                                          enable_open_in_editor=True,
+                                          tempfile_suffix=".js")
                 self._dumb_stdin_reader = None
             else:
                 self._cli = None

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -56,7 +56,8 @@ def main():
                                           style=style,
                                           history=history,
                                           completer=self._completer,
-                                          complete_in_thread=True)
+                                          complete_in_thread=True,
+                                          enable_open_in_editor=True)
                 self._dumb_stdin_reader = None
             else:
                 self._cli = None


### PR DESCRIPTION
My one liners were getting too long and apparently prompt toolkit have a feature to edit the prompt in the editor just like in a normal shell. I just pass the argument so it would enable it