### PR TITLE
Abort return values completion instead of crashing

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -775,6 +775,9 @@ URL: {url}
                             before_dot = '0.0' + before_dot
                         elif t[0] == Token.Punctuation and t[1] == ']':
                             before_dot = '[]' + before_dot
+                        elif t[0] == Token.Punctuation and t[1] == ')':
+                            # we don't know the returned value of the function call so we abort the completion
+                            return
 
                     break
 


### PR DESCRIPTION
The current completion implementation is simple and can't know the
return type of the function without calling it (a big no no). Until
there is a better solution we should abort the completion instead of
showing an annoying error message to the user.