### PR TITLE
Use default handler for SIGPIPE

### DIFF
--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -80,6 +80,10 @@ class ConsoleApplication(object):
     def __init__(self, run_until_return=await_enter, on_stop=None):
         plain_terminal = os.environ.get("TERM", "").lower() == "none"
 
+        # Windows doesn't have SIGPIPE
+        if hasattr(signal, "SIGPIPE"):
+            signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
         colorama.init(strip=True if plain_terminal else None)
 
         parser = OptionParser(usage=self._usage(), version=frida.__version__)


### PR DESCRIPTION
Python override the SIGPIPE signal handler with its own handler. Ideally we would leave the default handler and catch the raised exception (BrokenPipeError) but there's no way to supress the unhandled error completly. So instead of catching the exception we prevent it from being raised by using the default handler.

Should fix #16 