### PR TITLE
Use UTF-8 encoding when writing tracer handler

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -636,7 +636,7 @@ class FileRepository(Repository):
             handler_dir = os.path.dirname(handler_file)
             if not os.path.isdir(handler_dir):
                 os.makedirs(handler_dir)
-            with open(handler_file, 'w') as f:
+            with open(handler_file, 'w', encoding='utf-8') as f:
                 f.write(handler)
             self._notify_create(target, handler, handler_file)
 

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -636,7 +636,7 @@ class FileRepository(Repository):
             handler_dir = os.path.dirname(handler_file)
             if not os.path.isdir(handler_dir):
                 os.makedirs(handler_dir)
-            with open(handler_file, 'w', encoding='utf-8') as f:
+            with codecs.open(handler_file, 'w', 'utf-8') as f:
                 f.write(handler)
             self._notify_create(target, handler, handler_file)
 


### PR DESCRIPTION
Python tries to write the handler using cp1252 on Windows, which triggers an UnicodeEncodeError exception when it encounters chinese characters. Specifying UTF-8 as our encoding fixes the issue.