### PR TITLE
Migrate from deprecated optparse to argparse

### DIFF
--- a/frida_tools/apk.py
+++ b/frida_tools/apk.py
@@ -12,10 +12,10 @@ def main() -> None:
 
     class ApkApplication(ConsoleApplication):
         def _usage(self):
-            return "usage: %prog [options] path.apk"
+            return "%(prog)s [options] path.apk"
 
         def _add_options(self, parser):
-            parser.add_option("-o", "--output", help="output path", metavar="OUTPUT", type="string")
+            parser.add_argument("-o", "--output", help="output path", metavar="OUTPUT")
 
         def _needs_device(self):
             return False

--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -13,12 +13,12 @@ def main():
 
     class CreatorApplication(ConsoleApplication):
         def _usage(self):
-            return "usage: %prog [options] agent|cmodule"
+            return "%(prog)s [options] agent|cmodule"
 
         def _add_options(self, parser):
             default_project_name = os.path.basename(os.getcwd())
-            parser.add_option("-n", "--project-name", help="project name", dest="project_name", default=default_project_name)
-            parser.add_option("-o", "--output-directory", help="output directory", dest="outdir", default=".")
+            parser.add_argument("-n", "--project-name", help="project name", dest="project_name", default=default_project_name)
+            parser.add_argument("-o", "--output-directory", help="output directory", dest="outdir", default=".")
 
         def _initialize(self, parser, options, args):
             if len(args) != 1:

--- a/frida_tools/discoverer.py
+++ b/frida_tools/discoverer.py
@@ -21,7 +21,7 @@ def main():
                 self._results_received.wait(0.5)
 
         def _usage(self):
-            return "usage: %prog [options] target"
+            return "%(prog)s [options] target"
 
         def _initialize(self, parser, options, args):
             self._discoverer = None

--- a/frida_tools/join.py
+++ b/frida_tools/join.py
@@ -14,17 +14,13 @@ def main():
             ConsoleApplication.__init__(self, self._await_ctrl_c)
 
         def _usage(self):
-            return "usage: %prog [options] target portal-location [portal-certificate] [portal-token]"
+            return "%(prog)s [options] target portal-location [portal-certificate] [portal-token]"
 
         def _add_options(self, parser):
-            parser.add_option("--portal-location", help="join portal at LOCATION",
-                    metavar="LOCATION", type='string', action='store', dest="portal_location", default=None)
-            parser.add_option("--portal-certificate", help="speak TLS with portal, expecting CERTIFICATE",
-                    metavar="CERTIFICATE", type='string', action='store', dest="portal_certificate", default=None)
-            parser.add_option("--portal-token", help="authenticate with portal using TOKEN",
-                    metavar="TOKEN", type='string', action='store', dest="portal_token", default=None)
-            parser.add_option("--portal-acl-allow", help="limit portal access to control channels with TAG",
-                    metavar="TAG", type='string', action='append', dest="portal_acl", default=None)
+            parser.add_argument("--portal-location", help="join portal at LOCATION", metavar="LOCATION", dest="portal_location")
+            parser.add_argument("--portal-certificate", help="speak TLS with portal, expecting CERTIFICATE", metavar="CERTIFICATE", dest="portal_certificate")
+            parser.add_argument("--portal-token", help="authenticate with portal using TOKEN", metavar="TOKEN", dest="portal_token")
+            parser.add_argument("--portal-acl-allow", help="limit portal access to control channels with TAG", metavar="TAG", action='append', dest="portal_acl")
 
         def _initialize(self, parser, options, args):
             location = args[0] if len(args) >= 1 else options.portal_location

--- a/frida_tools/kill.py
+++ b/frida_tools/kill.py
@@ -8,7 +8,7 @@ def main():
 
     class KillApplication(ConsoleApplication):
         def _usage(self):
-            return "usage: %prog [options] process"
+            return "%(prog)s [options] process"
 
         def _initialize(self, parser, options, args):
             if len(args) < 1:

--- a/frida_tools/lsd.py
+++ b/frida_tools/lsd.py
@@ -8,7 +8,7 @@ def main():
 
     class LSDApplication(ConsoleApplication):
         def _usage(self):
-            return "usage: %prog [options]"
+            return "%(prog)s [options]"
 
         def _needs_device(self):
             return False

--- a/frida_tools/ps.py
+++ b/frida_tools/ps.py
@@ -19,12 +19,9 @@ def main():
 
     class PSApplication(ConsoleApplication):
         def _add_options(self, parser):
-            parser.add_option("-a", "--applications", help="list only applications",
-                action='store_true', dest="list_only_applications", default=False)
-            parser.add_option("-i", "--installed", help="include all installed applications",
-                action='store_true', dest="include_all_applications", default=False)
-            parser.add_option("-j", "--json", help="output results as JSON",
-                action='store_const', dest="output_format", const='json', default='text')
+            parser.add_argument("-a", "--applications", help="list only applications", action='store_true', dest="list_only_applications", default=False)
+            parser.add_argument("-i", "--installed", help="include all installed applications", action='store_true', dest="include_all_applications", default=False)
+            parser.add_argument("-j", "--json", help="output results as JSON", action='store_const', dest="output_format", const='json', default='text')
 
         def _initialize(self, parser, options, args):
             if options.include_all_applications and not options.list_only_applications:
@@ -35,7 +32,7 @@ def main():
             self._terminal_type, self._icon_size = self._detect_terminal()
 
         def _usage(self):
-            return "usage: %prog [options]"
+            return "%(prog)s [options]"
 
         def _start(self):
             if self._list_only_applications:

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -67,27 +67,17 @@ def main():
                 self._rpc_complete_server = start_completion_thread(self)
 
         def _add_options(self, parser):
-            parser.add_option("-l", "--load", help="load SCRIPT", metavar="SCRIPT",
-                              type='string', action='store', dest="user_script", default=None)
-            parser.add_option("-P", "--parameters", help="parameters as JSON, same as Gadget", metavar="PARAMETERS_JSON",
-                              type='string', action='store', dest="user_parameters", default=None)
-            parser.add_option("-C", "--cmodule", help="load CMODULE", metavar="CMODULE",
-                              type='string', action='store', dest="user_cmodule", default=None)
-            parser.add_option("--toolchain", help="CModule toolchain to use when compiling from source code",
-                              metavar="any|internal|external", type='choice', choices=['any', 'internal', 'external'], default='any')
-            parser.add_option("-c", "--codeshare", help="load CODESHARE_URI", metavar="CODESHARE_URI",
-                              type='string', action='store', dest="codeshare_uri", default=None)
-            parser.add_option("-e", "--eval", help="evaluate CODE", metavar="CODE",
-                              type='string', action='append', dest="eval_items", default=None)
-            parser.add_option("-q", help="quiet mode (no prompt) and quit after -l and -e",
-                              action='store_true', dest="quiet", default=False)
-            parser.add_option("--no-pause", help="automatically start main thread after startup",
-                              action='store_true', dest="no_pause", default=False)
-            parser.add_option("-o", "--output", help="output to log file", dest="logfile", default=None)
-            parser.add_option("--eternalize", help="eternalize the script before exit",
-                              action='store_true', dest="eternalize", default=False)
-            parser.add_option("--exit-on-error", help="exit with code 1 after encountering any exception in the SCRIPT",
-                              action='store_true', dest="exit_on_error", default=False)
+            parser.add_argument("-l", "--load", help="load SCRIPT", metavar="SCRIPT", dest="user_script")
+            parser.add_argument("-P", "--parameters", help="parameters as JSON, same as Gadget", metavar="PARAMETERS_JSON", dest="user_parameters")
+            parser.add_argument("-C", "--cmodule", help="load CMODULE", dest="user_cmodule")
+            parser.add_argument("--toolchain", help="CModule toolchain to use when compiling from source code", choices=['any', 'internal', 'external'], default='any')
+            parser.add_argument("-c", "--codeshare", help="load CODESHARE_URI", metavar="CODESHARE_URI", dest="codeshare_uri")
+            parser.add_argument("-e", "--eval", help="evaluate CODE", metavar="CODE", action='append', dest="eval_items")
+            parser.add_argument("-q", help="quiet mode (no prompt) and quit after -l and -e", action='store_true', dest="quiet", default=False)
+            parser.add_argument("--no-pause", help="automatically start main thread after startup", action='store_true', dest="no_pause", default=False)
+            parser.add_argument("-o", "--output", help="output to log file", dest="logfile")
+            parser.add_argument("--eternalize", help="eternalize the script before exit", action='store_true', dest="eternalize", default=False)
+            parser.add_argument("--exit-on-error", help="exit with code 1 after encountering any exception in the SCRIPT", action='store_true', dest="exit_on_error", default=False)
 
         def _initialize(self, parser, options, args):
             if options.user_script is not None:
@@ -137,7 +127,7 @@ def main():
                 self._logfile.write(text + "\n")
 
         def _usage(self):
-            return "usage: %prog [options] target"
+            return "%(prog)s [options] target"
 
         def _needs_target(self):
             return True

--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -29,43 +29,27 @@ def main():
 
         def _add_options(self, parser):
             pb = TracerProfileBuilder()
-            def process_builder_arg(option, opt_str, value, parser, method, **kwargs):
-                method(value)
-            parser.add_option("-I", "--include-module", help="include MODULE", metavar="MODULE",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_modules,))
-            parser.add_option("-X", "--exclude-module", help="exclude MODULE", metavar="MODULE",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.exclude_modules,))
-            parser.add_option("-i", "--include", help="include [MODULE!]FUNCTION", metavar="FUNCTION",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include,))
-            parser.add_option("-x", "--exclude", help="exclude [MODULE!]FUNCTION", metavar="FUNCTION",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.exclude,))
-            parser.add_option("-a", "--add", help="add MODULE!OFFSET", metavar="MODULE!OFFSET",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_relative_address,))
-            parser.add_option("-T", "--include-imports", help="include program's imports",
-                    action='callback', callback=process_builder_arg, callback_args=(pb.include_imports,))
-            parser.add_option("-t", "--include-module-imports", help="include MODULE imports", metavar="MODULE",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_imports,))
-            parser.add_option("-m", "--include-objc-method", help="include OBJC_METHOD", metavar="OBJC_METHOD",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_objc_method,))
-            parser.add_option("-M", "--exclude-objc-method", help="exclude OBJC_METHOD", metavar="OBJC_METHOD",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.exclude_objc_method,))
-            parser.add_option("-j", "--include-java-method", help="include JAVA_METHOD", metavar="JAVA_METHOD",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_java_method,))
-            parser.add_option("-J", "--exclude-java-method", help="exclude JAVA_METHOD", metavar="JAVA_METHOD",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.exclude_java_method,))
-            parser.add_option("-s", "--include-debug-symbol", help="include DEBUG_SYMBOL", metavar="DEBUG_SYMBOL",
-                    type='string', action='callback', callback=process_builder_arg, callback_args=(pb.include_debug_symbol,))
-            parser.add_option("-q", "--quiet", help="do not format output messages", action='store_true', default=False)
-            parser.add_option("-d", "--decorate", help="add module name to generated onEnter log statement", action='store_true', default=False)
-            parser.add_option("-S", "--init-session", help="path to JavaScript file used to initialize the session", metavar="PATH",
-                    type='string', action='append', default=[])
-            parser.add_option("-P", "--parameters", help="parameters as JSON, exposed as a global named 'parameters'", metavar="PARAMETERS_JSON",
-                    type='string', action='store', default=None)
-            parser.add_option("-o", "--output", help="dump messages to file", metavar="OUTPUT", type='string')
+            parser.add_argument("-I", "--include-module", help="include MODULE", metavar="MODULE", type=pb.include_modules)
+            parser.add_argument("-X", "--exclude-module", help="exclude MODULE", metavar="MODULE", type=pb.exclude_modules)
+            parser.add_argument("-i", "--include", help="include [MODULE!]FUNCTION", metavar="FUNCTION", type=pb.include)
+            parser.add_argument("-x", "--exclude", help="exclude [MODULE!]FUNCTION", metavar="FUNCTION", type=pb.exclude)
+            parser.add_argument("-a", "--add", help="add MODULE!OFFSET", metavar="MODULE!OFFSET", type=pb.include_relative_address)
+            parser.add_argument("-T", "--include-imports", help="include program's imports", type=pb.include_imports)
+            parser.add_argument("-t", "--include-module-imports", help="include MODULE imports", metavar="MODULE", type=pb.include_imports)
+            parser.add_argument("-m", "--include-objc-method", help="include OBJC_METHOD", metavar="OBJC_METHOD", type=pb.include_objc_method)
+            parser.add_argument("-M", "--exclude-objc-method", help="exclude OBJC_METHOD", metavar="OBJC_METHOD", type=pb.exclude_objc_method)
+            parser.add_argument("-j", "--include-java-method", help="include JAVA_METHOD", metavar="JAVA_METHOD", type=pb.include_java_method)
+            parser.add_argument("-J", "--exclude-java-method", help="exclude JAVA_METHOD", metavar="JAVA_METHOD", type=pb.exclude_java_method)
+            parser.add_argument("-s", "--include-debug-symbol", help="include DEBUG_SYMBOL", metavar="DEBUG_SYMBOL", type=pb.include_debug_symbol)
+            parser.add_argument("-q", "--quiet", help="do not format output messages", action='store_true', default=False)
+            parser.add_argument("-d", "--decorate", help="add module name to generated onEnter log statement", action='store_true', default=False)
+            parser.add_argument("-S", "--init-session", help="path to JavaScript file used to initialize the session", metavar="PATH", action='append', default=[])
+            parser.add_argument("-P", "--parameters", help="parameters as JSON, exposed as a global named 'parameters'", metavar="PARAMETERS_JSON")
+            parser.add_argument("-o", "--output", help="dump messages to file", metavar="OUTPUT")
             self._profile_builder = pb
 
         def _usage(self):
-            return "usage: %prog [options] target"
+            return "%(prog)s [options] target"
 
         def _initialize(self, parser, options, args):
             self._tracer = None


### PR DESCRIPTION
Optparse is deprecated since Python 3.2 (more than 10 years ago!) so it's time to migrate to the newer argparse module that is still supported.

There wasn't much to change because argparse tries as best as it can to be backward compatible. Mostly what was changed is callback arguments and handling of extra arguments.

I also deleted redundant arguments that were the default anyway.

There's still more testing to do, that is why I marked it as WIP but I wanted to get feedback as soon as possible and I hope there won't be any more changes, except bug fixes of course.