### PR TITLE
Add exec magic command to the REPL

### DIFF
--- a/frida_tools/_repl_magic.py
+++ b/frida_tools/_repl_magic.py
@@ -1,5 +1,7 @@
 import abc
+import codecs
 import json
+import os
 
 
 class Magic(abc.ABC):
@@ -66,6 +68,29 @@ class Autoperform(Magic):
 
     def execute(self, repl, args):
         repl._autoperform_command(args[0])
+
+
+class Exec(Magic):
+    @property
+    def description(self):
+        return "execute the given file path in the context of the currently loaded scripts"
+
+    @property
+    def required_args_count(self):
+        return 1
+
+    def execute(self, repl, args):
+        if not os.path.exists(args[0]):
+            repl._print("Can't read the given file because it does not exist")
+            return
+
+        try:
+            with codecs.open(args[0], 'rb', 'utf-8') as f:
+                if not repl._eval_and_print(f.read()):
+                    repl._errors += 1
+        except PermissionError:
+            repl._print("Can't read the given file because of a permission error")
+
 
 
 class Time(Magic):

--- a/frida_tools/_repl_magic.py
+++ b/frida_tools/_repl_magic.py
@@ -92,7 +92,6 @@ class Exec(Magic):
             repl._print("Can't read the given file because of a permission error")
 
 
-
 class Time(Magic):
     @property
     def description(self):

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -431,6 +431,7 @@ def main():
             'reload': _repl_magic.Reload(),
             'unload': _repl_magic.Unload(),
             'autoperform': _repl_magic.Autoperform(),
+            'exec': _repl_magic.Exec(),
             'time': _repl_magic.Time(),
             'help': _repl_magic.Help()
         }


### PR DESCRIPTION
Sometimes you want to execute a multiline script after you've already opened the REPL and you don't want to close it and lose all state. The exec command will let the user execute a file from the REPL while running, just like typing the code manually.

Again I'm basing this patch on the magics refactors so it won't cause too much conflicts