### PR TITLE
Fix `'REPLApplication' object has no attribute '_get_or_create_truststore_file'` error

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -750,7 +750,7 @@ URL: {url}
 
             return trust_store
 
-        def _get_truststore_file(self):
+        def _get_or_create_truststore_file(self):
             truststore_file = os.path.join(self._get_or_create_data_dir(), 'codeshare-truststore.json')
             if not os.path.isfile(truststore_file):
                 self._migrate_old_config_file('codeshare-truststore.json', truststore_file)


### PR DESCRIPTION
Exception stack trace:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "...REDACTED...\Python39\lib\threading.py", line 973, in _bootstrap_inner
    self.run()
  File "...REDACTED...\Python39\lib\threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "...REDACTED...\Python39\lib\site-packages\frida_tools\application.py", line 796, in _run
    work()
  File "...REDACTED...\Python39\lib\site-packages\frida_tools\application.py", line 394, in _try_start
    self._start()
  File "...REDACTED...\Python39\lib\site-packages\frida_tools\repl.py", line 143, in _start
    self._codeshare_script = self._load_codeshare_script(self._codeshare_uri)
  File "...REDACTED...\Python39\lib\site-packages\frida_tools\repl.py", line 674, in _load_codeshare_script
    trust_store = self._get_or_create_truststore()
  File "...REDACTED...\Python39\lib\site-packages\frida_tools\repl.py", line 735, in _get_or_create_truststore
    codeshare_trust_store = self._get_or_create_truststore_file()
AttributeError: 'REPLApplication' object has no attribute '_get_or_create_truststore_file'
```