### PR TITLE
Fix creator.py

### DIFF
--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -13,19 +13,19 @@ def main():
 
     class CreatorApplication(ConsoleApplication):
         def _usage(self):
-            return "%(prog)s [options] agent|cmodule"
+            return "%(prog)s [options] -m agent|cmodule"
 
         def _add_options(self, parser):
             default_project_name = os.path.basename(os.getcwd())
             parser.add_argument("-n", "--project-name", help="project name", dest="project_name", default=default_project_name)
             parser.add_argument("-o", "--output-directory", help="output directory", dest="outdir", default=".")
+            parser.add_argument("-m", "--template", help="template file: cmodule|agent", dest="template", default=None)
 
-        def _initialize(self, parser, options, args):
-            if len(args) != 1:
+        def _initialize(self, parser, options, args):    
+            args = parser.parse_args()
+            if not args.template:
                 parser.error("template must be specified")
-
-            template = args[0]
-            impl = getattr(self, "_generate_" + template, None)
+            impl = getattr(self, "_generate_" + args.template, None)
             if impl is None:
                 parser.error("unknown template type")
             self._generate = impl

--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -13,13 +13,13 @@ def main():
 
     class CreatorApplication(ConsoleApplication):
         def _usage(self):
-            return "%(prog)s [options] -m agent|cmodule"
+            return "%(prog)s [options] -t agent|cmodule"
 
         def _add_options(self, parser):
             default_project_name = os.path.basename(os.getcwd())
             parser.add_argument("-n", "--project-name", help="project name", dest="project_name", default=default_project_name)
             parser.add_argument("-o", "--output-directory", help="output directory", dest="outdir", default=".")
-            parser.add_argument("-m", "--template", help="template file: cmodule|agent", dest="template", default=None)
+            parser.add_argument("-t", "--template", help="template file: cmodule|agent", dest="template", default=None)
 
         def _initialize(self, parser, options, args):    
             args = parser.parse_args()


### PR DESCRIPTION
frida-create was not working properly

```
C:\Users\xxx\Desktop\reversing\cmod>frida-create cmodule
usage: frida-create [options] agent|cmodule
frida-create: error: unrecognized arguments: cmodule
```

Output after changes:

```
C:\Users\xxx\Desktop\reversing\cmod>frida-create -m cmodule
Created .\meson.build
Created .\cmod.c
Created .\.gitignore
Created .\include/glib.h
Created .\include/gum/gumdefs.h
Created .\include/gum/guminterceptor.h
Created .\include/gum/gummemory.h
Created .\include/gum/gummetalarray.h
Created .\include/gum/gummetalhash.h
Created .\include/gum/gummodulemap.h
Created .\include/gum/gumprocess.h
Created .\include/gum/gumspinlock.h
Created .\include/gum/gumstalker.h
Created .\include/gum/gumtls.h
Created .\include/json-glib/json-glib.h
Created .\include/gum/arch-x86/gumx86writer.h
Created .\include/capstone.h
Created .\include/platform.h
Created .\include/x86.h

Run `meson build && ninja -C build` to build, then:
- Inject CModule using the REPL: frida Calculator -C .\build\cmod.dll
- Edit *.c, and build incrementally through `ninja -C build`
- REPL will live-reload whenever .\build\cmod.dll changes on disk
```

