### PR TITLE
fix `frida-apk` argument parsing

### DIFF
--- a/frida_tools/apk.py
+++ b/frida_tools/apk.py
@@ -16,16 +16,15 @@ def main() -> None:
 
         def _add_options(self, parser):
             parser.add_argument("-o", "--output", help="output path", metavar="OUTPUT")
+            parser.add_argument("apk", help="apk file")
 
         def _needs_device(self):
             return False
 
         def _initialize(self, parser, options, args):
             self._output_path = options.output
+            self._path = options.apk
 
-            if len(args) < 1:
-                parser.error("path must be specified")
-            self._path = args[0]
             if not self._path.endswith(".apk"):
                 parser.error("path must end in .apk")
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 pkg_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "frida_tools"))
 
 agents = glob.glob(os.path.join(pkg_dir, "*_agent.*"))
-assert len(agents) > 0, "Agents not compiled; run “npm install” in agents/"
+assert len(agents) > 0, "Agents not compiled; run “npm install && npm run build” in agents/tracer/"
 
 setup(
     name="frida-tools",


### PR DESCRIPTION
This PR fixes the argument parsing for `frida-apk`, which previously failed as follows after the argparse migration:

```console
$ frida-apk
usage: frida-apk [options] path.apk
frida-apk: error: path must be specified
$ frida-apk path.apk
usage: frida-apk [options] path.apk
frida-apk: error: unrecognized arguments: path.apk
```