### PR TITLE
`frida-apk`: Add support for ResourceMap, ordered inserts

### DIFF
--- a/frida_tools/apk.py
+++ b/frida_tools/apk.py
@@ -85,8 +85,12 @@ def debug(path: str, output_path: str) -> None:
                         data.extend(header.chunk_data)
 
                     oz.writestr(info.filename, bytes(data), info.compress_type)
-                elif info.filename.startswith("META-INF"):
-                    pass
+                elif info.filename.upper() == "META-INF/MANIFEST.MF":
+                    # Historically frida-apk deleted META-INF/ entirely, but that breaks some apps.
+                    # It turns out that v1 signatures (META-INF/MANIFEST.MF) are not validated at all on
+                    # modern Android versions, so we can keep them in for now.
+                    # If this doesn't work for you, try to comment out the following line.
+                    oz.writestr(info.filename, f.read(), info.compress_type)
                 else:
                     oz.writestr(info.filename, f.read(), info.compress_type)
 


### PR DESCRIPTION
This PR makes `frida-apk` work with my Android 12 Pixel 3 device (stock ROM, no root).

See the 9285b273de68e3c95a22c713d9840bf9d21e6e8b commit message for a detailed explanation of the changes. I've taken the liberty to build this on top of #95, which hopefully should be uncontroversial.

FWIW I've built a small tool around this for certificate pinning (https://github.com/mitmproxy/android-unpinner). If you folks feel that the JDWP stuff is useful, please feel free to shamelessly copy it.