### PR TITLE
Use shlex instead of str.split for magic commands

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals, print_function
 
 import os
+import shlex
 import signal
 import string
 import threading
@@ -437,7 +438,7 @@ def main():
         }
 
         def _do_magic(self, statement):
-            tokens = statement.split(" ")
+            tokens = shlex.split(statement)
             command = tokens[0]
             args = tokens[1:]
 


### PR DESCRIPTION
The shlex module is more suitable for shells and let us support quoting
and escaping without any extra work. It's important to have that now to
support paths with spaces in them.