### PR TITLE
repl: Add load command

### DIFF
--- a/frida_tools/_repl_magic.py
+++ b/frida_tools/_repl_magic.py
@@ -30,6 +30,30 @@ class Resume(Magic):
         repl._reactor.schedule(lambda: repl._resume())
 
 
+class Load(Magic):
+    @property
+    def description(self):
+        return "Load an additional script and reload the current REPL state"
+
+    @property
+    def required_args_count(self):
+        return 1
+
+    def execute(self, repl, args):
+        try:
+            proceed = repl._get_confirmation(
+                "Are you sure you want to load a new script and discard all current state?"
+            )
+            if not proceed:
+                repl._print("Discarding load command")
+                return
+
+            repl._user_scripts.append(args[0])
+            repl._perform_on_reactor_thread(lambda: repl._load_script())
+        except Exception as e:
+            repl._print("Failed to load script: {}".format(e))
+
+
 class Reload(Magic):
     @property
     def description(self):
@@ -60,7 +84,9 @@ class Unload(Magic):
 class Autoperform(Magic):
     @property
     def description(self):
-        return "receive on/off as first and only argument, when switched on will wrap any REPL code with Java.performNow()"
+        return (
+            "receive on/off as first and only argument, when switched on will wrap any REPL code with Java.performNow()"
+        )
 
     @property
     def required_args_count(self):
@@ -112,7 +138,7 @@ class Exec(Magic):
             return
 
         try:
-            with codecs.open(args[0], 'rb', 'utf-8') as f:
+            with codecs.open(args[0], "rb", "utf-8") as f:
                 if not repl._eval_and_print(f.read()):
                     repl._errors += 1
         except PermissionError:
@@ -129,14 +155,18 @@ class Time(Magic):
         return -2
 
     def execute(self, repl, args):
-        repl._eval_and_print('''
+        repl._eval_and_print(
+            """
             (() => {{
                 const _startTime = Date.now();
                 const _result = eval({expression});
                 const _endTime = Date.now();
                 console.log('Time: ' + (_endTime - _startTime) + ' ms.');
                 return _result;
-            }})();'''.format(expression=json.dumps(" ".join(args))))
+            }})();""".format(
+                expression=json.dumps(" ".join(args))
+            )
+        )
 
 
 class Help(Magic):

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -24,6 +24,7 @@ def main():
 
     from colorama import Fore, Style
     import frida
+    from prompt_toolkit.shortcuts import prompt
     from prompt_toolkit import PromptSession
     from prompt_toolkit.history import FileHistory
     from prompt_toolkit.completion import Completion, Completer
@@ -373,6 +374,27 @@ def main():
                     except frida.OperationCancelledError:
                         return
 
+        def _get_confirmation(self, question, default_answer = False):
+            if default_answer:
+                prompt_string = question + " [Y/n] "
+            else:
+                prompt_string = question + " [y/N] "
+
+            if self._have_terminal and not self._plain_terminal:
+                answer = prompt(prompt_string)
+            else:
+                answer = self._dumb_stdin_reader.read_line(prompt_string)
+                self._print(answer)
+
+            if answer.lower() not in ("y", "yes", "n", "no", ""):
+                return self._get_confirmation(question, default_answer=default_answer)
+
+            if default_answer:
+                return answer.lower() != "n" and answer.lower() != "no"
+
+            return answer.lower() == "y" or answer.lower() == "yes"
+
+
         def _eval_and_print(self, expression):
             success = False
             try:
@@ -452,6 +474,7 @@ def main():
         # Negative means at least abs(val) - 1
         _magic_command_args = {
             'resume': _repl_magic.Resume(),
+            'load': _repl_magic.Load(),
             'reload': _repl_magic.Reload(),
             'unload': _repl_magic.Unload(),
             'autoperform': _repl_magic.Autoperform(),


### PR DESCRIPTION
The load command add the given script to the list of users scripts and reload the REPL state to use all the new scripts. Because of its destructive behaviour, there is a confirmation message before loading any given script through the magic command.

Resolves #84 