### PR TITLE
bugfix: rows could be empty

### DIFF
--- a/frida_tools/ls.py
+++ b/frida_tools/ls.py
@@ -75,7 +75,7 @@ class LsApplication(ConsoleApplication):
                 mtime = datetime.fromtimestamp(raw_mtime / 1000.0, tz=timezone.utc)
                 rows.append((type + access, str(nlink), owner, group, str(size), mtime.strftime("%c"), name, target))
             
-            if not len(rows):
+            if len(rows) == 0:
                 break
 
             widths = []

--- a/frida_tools/ls.py
+++ b/frida_tools/ls.py
@@ -74,6 +74,9 @@ class LsApplication(ConsoleApplication):
             for name, target, type, access, nlink, owner, group, size, raw_mtime in group["entries"]:
                 mtime = datetime.fromtimestamp(raw_mtime / 1000.0, tz=timezone.utc)
                 rows.append((type + access, str(nlink), owner, group, str(size), mtime.strftime("%c"), name, target))
+            
+            if not len(rows):
+                break
 
             widths = []
             for column_index in range(len(rows[0]) - 2):


### PR DESCRIPTION
When the path does not exist, rows will be empty, causing `IndexError: list index out of range`

**Before**

```
frida-ls -U /etc/passwd1
Waiting for USB device to appear...
No such file or directory
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\threading.py", line 980, in _bootstrap_inner
    self.run()
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\chich\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\frida_tools\application.py", line 836, in _run
    work()
  File "C:\Users\chich\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\frida_tools\application.py", line 432, in _try_start
    self._start()
  File "C:\Users\chich\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\frida_tools\ls.py", line 78, in _start
    for column_index in range(len(rows[0]) - 2):
IndexError: list index out of range
```

**After**

```
frida-ls -U /etc/passwd1
No such file or directory
```
