### PR TITLE
add reactor.py to sources

### DIFF
--- a/frida_tools/meson.build
+++ b/frida_tools/meson.build
@@ -15,6 +15,7 @@ sources = [
   'ps.py',
   'pull.py',
   'push.py',
+  'reactor.py',
   'repl.py',
   'rm.py',
   'tracer.py',


### PR DESCRIPTION
I saw a failure trying to build and use tools:

```
$ ./build/frida-macos-arm64/bin/frida-ls-devices
Traceback (most recent call last):
  File "/Users/tmm1/fancybits/frida/./build/frida-macos-arm64/bin/frida-ls-devices", line 10, in <module>
    frida_tools.lsd.main()
  File "/Users/tmm1/fancybits/frida/build/frida-macos-arm64/lib/python3.10/site-packages/frida_tools/lsd.py", line 6, in main
    from frida_tools.application import ConsoleApplication
  File "/Users/tmm1/fancybits/frida/build/frida-macos-arm64/lib/python3.10/site-packages/frida_tools/application.py", line 25, in <module>
    from frida_tools.reactor import Reactor
ModuleNotFoundError: No module named 'frida_tools.reactor'
```