### PR TITLE
frida-tools package is not zip_safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pygments >= 2.0.2, < 3.0.0",
     ],
     license="wxWindows Library Licence, Version 3.1",
-    zip_safe=True,
+    zip_safe=False,
     keywords="frida debugger dynamic instrumentation inject javascript windows macos linux ios iphone ipad android qnx",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
tracer.py uses relative path to locate `tracer_agent.js`. If the package has been installed as zip (.egg), `frida-trace`  can't read from the tracer template, thus result in failure.

To reproduce, clone this repo and run `python3 setup.py install` on a clean machine (that has not installed `frida-tools` before), then use `frida-trace` command. Then it will complain `[Errno 20] Not a directory: ...tracer_agent.js`

