### PR TITLE
Fix type hinting in frida-creator

### DIFF
--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -146,7 +146,7 @@ Tip: Use an editor like Visual Studio Code for code completion, inline docs,
 
             return (assets, message)
 
-        def _generate_cmodule(self) -> tuple[dict[str, str], str]:
+        def _generate_cmodule(self) -> Tuple[Dict[str, str], str]:
             assets = {}
 
             assets[


### PR DESCRIPTION
lowercase tuple and dict are only supported from Python 3.9, so we will use the old way of an uppercase Tuple and Dict from the typing package.