### PR TITLE
Fix folders/files name generation inside __handlers__

### DIFF
--- a/agents/tracer/agent.ts
+++ b/agents/tracer/agent.ts
@@ -636,7 +636,7 @@ function receiveResponse<T>(type: string): Promise<T> {
 }
 
 function moduleFunctionTargetFromMatch(m: ApiResolverMatch): NativeTarget {
-    const [modulePath, functionName] = m.name.split("!", 2);
+    const [modulePath, functionName] = m.name.split("!").slice(-2);
     return ["c", modulePath, functionName];
 }
 


### PR DESCRIPTION
If you use frida-trace. on native functions inside specific Android application shared objects, the files and folders inside __handlers__,  are created with the wrong names. This patch fix this issue. 