### PR TITLE
Fix Stack Trace Trim

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -486,8 +486,9 @@ class REPLApplication(ConsoleApplication):
 
             stack = error.get("stack", None)
             if stack is not None:
+                message_len = len(error["message"].split("\n"))
                 trim_amount = 5 if self._runtime == "v8" else 6
-                trimmed_stack = stack.split("\n")[1:-trim_amount]
+                trimmed_stack = stack.split("\n")[message_len:-trim_amount]
                 if len(trimmed_stack) > 0:
                     output += "\n" + "\n".join(trimmed_stack)
         except frida.InvalidOperationError:

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -487,7 +487,7 @@ class REPLApplication(ConsoleApplication):
             stack = error.get("stack", None)
             if stack is not None:
                 message_len = len(error["message"].split("\n"))
-                trim_amount = 5 if self._runtime == "v8" else 6
+                trim_amount = 6 if self._runtime == "v8" else 7
                 trimmed_stack = stack.split("\n")[message_len:-trim_amount]
                 if len(trimmed_stack) > 0:
                     output += "\n" + "\n".join(trimmed_stack)


### PR DESCRIPTION
Fix an duplicate lines in multiline error messages.

for example:

```js
throw Error("test1\ntest2\ntest3")
```
The code above would result in:
```
Error: test1
test2
test3
test2
test3
    at <eval> (<input>:1)
    at eval (native)
```

I also removed the last line in the stack trace, so the now the same code would result in:
```
Error: test1
test2
test3
    at <eval> (<input>:1)
```
