### PR TITLE
repl: Detach session before killing on exit

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -271,6 +271,8 @@ class REPLApplication(ConsoleApplication):
             self._logfile.close()
 
         if self._kill_on_exit and self._spawned_pid is not None:
+            if self._session is not None:
+                self._session.detach ()
             self._device.kill(self._spawned_pid)
 
         if not self._quiet:

--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -272,7 +272,7 @@ class REPLApplication(ConsoleApplication):
 
         if self._kill_on_exit and self._spawned_pid is not None:
             if self._session is not None:
-                self._session.detach ()
+                self._session.detach()
             self._device.kill(self._spawned_pid)
 
         if not self._quiet:


### PR DESCRIPTION
This is to avoid random hang on exit observed when using `--kill-on-exit` when spawning iOS apps, which after hitting CTRL+C results in:
```
Frida:ERROR:../../../frida-core/src/frida.vala:1409:_frida_device_release_session_co: assertion failed: (session_id != null)
Bail out! Frida:ERROR:../../../frida-core/src/frida.vala:1409:_frida_device_release_session_co: assertion failed: (session_id != null)
Abort trap: 6
```
