### PR TITLE
application.py: Respond to NO_COLOR environment variable.

### DIFF
--- a/frida_tools/application.py
+++ b/frida_tools/application.py
@@ -147,7 +147,10 @@ class ConsoleApplication:
         if hasattr(signal, "SIGPIPE"):
             signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-        colorama.init(strip=True if plain_terminal else None)
+        # If true, emit text without colors.  https://no-color.org/
+        no_color = plain_terminal or bool(os.environ.get("NO_COLOR"))
+
+        colorama.init(strip=True if no_color else None)
 
         parser = self._initialize_arguments_parser()
         real_args = compute_real_args(parser, args=args)


### PR DESCRIPTION
When `NO_COLOR` is set to a non-empty string, this disables emission of colored text, per the specification proposal at https://no-color.org/ .

In the modified code, setting `NO_COLOR` does *not* set the `plain_terminal` flag because that flows into `self._plain_terminal`, which is used elsewhere for things unrelated to colors.

Fixes frida/frida-tools#148.