### PR TITLE
skip typescript lint for generated code

### DIFF
--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -99,7 +99,8 @@ class CreatorApplication(ConsoleApplication):
     "strict": true,
     "esModuleInterop": true,
     "moduleResolution": "node16"
-  }
+  },
+  "exclude": ["_agent.js"]
 }
 """
 


### PR DESCRIPTION
when using IDE for this template, the linter also checks generated javascript, giving many non-sense errors like duplicated variable names

exclude generated code to tell the linter to ignore it