### PR TITLE
Fixed missing defineHandler in _create_stub_java_handler.

### DIFF
--- a/frida_tools/tracer.py
+++ b/frida_tools/tracer.py
@@ -792,7 +792,7 @@ defineHandler({
  * For full API reference, see: https://frida.re/docs/javascript-api/
  */
 
-{
+defineHandler({
   /**
    * Called synchronously when about to call %(display_name)s.
    *
@@ -820,7 +820,7 @@ defineHandler({
       log(`<= ${JSON.stringify(retval)}`);
     }
   }
-}
+});
 """ % {
             "display_name": target.display_name
         }


### PR DESCRIPTION
Fixes #162 by adding missing "defineHandler" into the _create_stub_java_handler.