### PR TITLE
apk: Support replacing existing debuggable attribute

### DIFF
--- a/frida_tools/apk.py
+++ b/frida_tools/apk.py
@@ -193,7 +193,7 @@ class StartElement:
         attr_offset = None
         replace = False
         for insert_pos in range(self.attribute_count + 1):
-            attr_offset = 0x24 + struct.calcsize(self.ATTRIBUTE_FORMAT) * insert_pos
+            attr_offset = 0x24 + insert_pos * struct.calcsize(self.ATTRIBUTE_FORMAT)
             idx = int.from_bytes(chunk_data[attr_offset + 4 : attr_offset + 8], "little")
             res = resource_map.get_resource(idx)
             if res >= ResourceMap.DEBUGGING_RESOURCE:

--- a/frida_tools/apk.py
+++ b/frida_tools/apk.py
@@ -197,7 +197,6 @@ class StartElement:
             idx = int.from_bytes(chunk_data[attr_offset + 4 : attr_offset + 8], "little")
             res = resource_map.get_resource(idx)
             if res >= ResourceMap.DEBUGGING_RESOURCE:
-                # If there's already a debugging resource, replace it.
                 replace = res == ResourceMap.DEBUGGING_RESOURCE
                 break
 


### PR DESCRIPTION
If a package explicitly specifies debuggable="false", adding a new entry setting it to "true" has no effect. To properly patch such APKs, we need to replace the entry.

This contribution is on behalf of my company.