### PR TITLE
apk: Allow injecting and configuring the Frida Gadget

### DIFF
--- a/completions/frida.fish
+++ b/completions/frida.fish
@@ -184,6 +184,7 @@ complete --command frida-create --no-files --require-parameter --short-option=t 
 add_base_arguments frida-apk
 complete --command frida-apk --force-files --short-option=o --long-option=output --description="output path"
 complete --command frida-apk --force-files --short-option=g --long-option=gadget --description="inject the specified gadget library"
+complete --command frida-apk --force-files --short-option=c --long-option=gadget-config --description="set the given key=value gadget interaction config"
 
 
 ######## frida-compile ########

--- a/completions/frida.fish
+++ b/completions/frida.fish
@@ -183,6 +183,7 @@ complete --command frida-create --no-files --require-parameter --short-option=t 
 ######## frida-apk ########
 add_base_arguments frida-apk
 complete --command frida-apk --force-files --short-option=o --long-option=output --description="output path"
+complete --command frida-apk --force-files --short-option=g --long-option=gadget --description="inject the specified gadget library"
 
 
 ######## frida-compile ########


### PR DESCRIPTION
Add a new -g/--gadget flag, which when passed causes frida-apk to inject the given Frida Gadget shared library. Along with the library itself, a [`wrap.sh` file](https://developer.android.com/ndk/guides/wrap-script) is injected that `LD_PRELOAD`s the gadget, which Android allows because we also make the app debuggable. The injected gadget can be configured with a new -c/--gadget-config flag, which overrides arbitrary entries in the injected [gadget config file](https://developer.android.com/ndk/guides/wrap-script).

This contribution is on behalf of my company.