### PR TITLE
repl: flush log to output

### DIFF
--- a/frida_tools/repl.py
+++ b/frida_tools/repl.py
@@ -209,6 +209,7 @@ class REPLApplication(ConsoleApplication):
         ConsoleApplication._log(self, level, text)
         if self._logfile is not None:
             self._logfile.write(text + "\n")
+            self._logfile.flush()
 
     def _usage(self) -> str:
         return "%(prog)s [options] target"


### PR DESCRIPTION
frida repl sometimes generates empty log file when using `--output` flag. 

Here is the minimal case to reproduce:

```objective-c
#import <Foundation/Foundation.h>

int main(int argc, const char * argv[]) {
    CFRunLoopRun();
    return 0;
}
```

* Compile with `cc main.m -o test -fmodules` 
* `frida -f ./test -e "console.log('foo')" -o log`

Log file will be empty.

----

Here is also an alternative way to fix:

```diff
- self._logfile = codecs.open(options.logfile, "w", "utf-8")
+ self._logfile = codecs.open(options.logfile, "w", "utf-8", buffering=0)
```

Since `tracer.py` is calling `flush()` explicitly, to keep the style consistent, this patch remains the same

https://github.com/frida/frida-tools/blob/233ab2b3c2cddb62afd58f1959600429cb8ad3f7/frida_tools/tracer.py#L1227-L1236