### PR TITLE
Prevent treeshake of frida-objc-bridge

### DIFF
--- a/bridges/rollup.config.ts
+++ b/bridges/rollup.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(BRIDGES.map(name => {
                         return {
                             code,
                             map: null,
-                            moduleSideEffects: 'no-treeshake',
+                            moduleSideEffects: "no-treeshake",
                         };
                     }
 

--- a/bridges/rollup.config.ts
+++ b/bridges/rollup.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(BRIDGES.map(name => {
         },
         plugins: [
              ({
-                name: 'disable-treeshake',
+                name: "disable-treeshake",
                 transform (code, id) {
                     if (/node_modules\/frida-objc-bridge/.test(id)) {
                         return {

--- a/bridges/rollup.config.ts
+++ b/bridges/rollup.config.ts
@@ -20,6 +20,20 @@ export default defineConfig(BRIDGES.map(name => {
             strict: false,
         },
         plugins: [
+             ({
+                name: 'disable-treeshake',
+                transform (code, id) {
+                    if (/node_modules\/frida-objc-bridge/.test(id)) {
+                        return {
+                            code,
+                            map: null,
+                            moduleSideEffects: 'no-treeshake',
+                        };
+                    }
+
+                    return null;
+                },
+            }),
             typescript(),
             polyfills(),
             resolve(),


### PR DESCRIPTION
This PR fixes an issue where `objc_msgSend` is dropped in the process of treeshaking where it sees `objc_msgSend` unused. The solution to this is disabling treeshake of `frida-objc-bridge` altogether.

This issue correctly fixes https://github.com/frida/frida-objc-bridge/issues/64 along with https://github.com/frida/frida/issues/3460.

Additionally, fixes https://github.com/frida/frida/issues/3480 which are all basically the same. 