### PR TITLE
Fix the `frida-create` template

### DIFF
--- a/frida_tools/creator.py
+++ b/frida_tools/creator.py
@@ -73,6 +73,7 @@ class CreatorApplication(ConsoleApplication):
   "version": "1.0.0",
   "description": "Frida agent written in TypeScript",
   "private": true,
+  "type": "module",
   "main": "agent/index.ts",
   "scripts": {{
     "prepare": "npm run build",
@@ -92,14 +93,14 @@ class CreatorApplication(ConsoleApplication):
         ] = """\
 {
   "compilerOptions": {
-    "target": "es2020",
-    "lib": ["es2020"],
+    "target": "es2022",
+    "lib": ["es2022"],
     "allowJs": true,
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
-    "module": "esnext"
+    "moduleResolution": "Node16",
+    "module": "Node16"
   },
   "exclude": ["_agent.js"]
 }


### PR DESCRIPTION
Fix multiple issues in the template used by `frida-create`

1. It seems typescript doesn't like the changes to tsconsfig's `moduleResolution` in https://github.com/frida/frida-tools/pull/183
I throw the following error:
```
tsconfig.json:8:25 - error TS5109: Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.
```

2. Imports are broken because the package is not specified as an ESModule in the `package.json`.
This causes the following error:
```
ReferenceError: 'exports' is not defined
    at <anonymous> (/agent/index.js:1)
``` 